### PR TITLE
Fixed error on compilation due to `thread` line in `_tags`

### DIFF
--- a/ocaml/_tags
+++ b/ocaml/_tags
@@ -1,1 +1,1 @@
-true: thread
+#true: thread


### PR DESCRIPTION
Just tried running it at another pc, weirdly it failed on this, which worked before