### PR TITLE
Couple of small, quick performance tweaks to reduce allocations

### DIFF
--- a/ocaml/ray.ml
+++ b/ocaml/ray.ml
@@ -172,11 +172,10 @@ let aabb_hit aabb (r: ray) tmin0 tmax0 =
     let invD = 1.0 /. dir' in
     let t0 = (min' -. origin') *. invD in
     let t1 = (max' -. origin') *. invD in
-    let (t0', t1') = if invD < 0.0 then (t1, t0) else (t0, t1) in
-    let tmin'' = max t0' tmin' in
-    let tmax'' = min t1' tmax' in
+    let tmin'' = max (if invD < 0.0 then t1 else t0) tmin' in
+    let tmax'' = min (if invD < 0.0 then t0 else t1) tmax' in
     (tmin'', tmax'')
-    [@@inline]
+    [@@inline always]
   in
   let (tmin1, tmax1) =
     iter aabb.min.x aabb.max.x r.origin.x r.dir.x tmin0 tmax0

--- a/ocaml/ray.ml
+++ b/ocaml/ray.ml
@@ -175,7 +175,7 @@ let aabb_hit aabb (r: ray) tmin0 tmax0 =
     let tmin'' = max (if invD < 0.0 then t1 else t0) tmin' in
     let tmax'' = min (if invD < 0.0 then t0 else t1) tmax' in
     (tmin'', tmax'')
-    [@@inline always]
+    [@@inline]
   in
   let (tmin1, tmax1) =
     iter aabb.min.x aabb.max.x r.origin.x r.dir.x tmin0 tmax0

--- a/ocaml/ray.ml
+++ b/ocaml/ray.ml
@@ -6,16 +6,10 @@ type vec3 = {
   z : float;
 }
 
-let vf f (v1: vec3) (v2: vec3) = {
-  x = f v1.x v2.x;
-  y = f v1.y v2.y;
-  z = f v1.z v2.z
-}
-
-let vec_add = vf (+.)
-let vec_sub = vf (-.)
-let vec_mul = vf ( *. )
-let vec_div = vf (/.)
+let vec_add (v1: vec3) (v2: vec3) = { x = v1.x +. v2.x; y = v1.y +. v2.y; z = v1.z +. v2.z }
+let vec_sub (v1: vec3) (v2: vec3) = { x = v1.x -. v2.x; y = v1.y -. v2.y; z = v1.z -. v2.z }
+let vec_mul (v1: vec3) (v2: vec3) = { x = v1.x *. v2.x; y = v1.y *. v2.y; z = v1.z *. v2.z }
+let vec_div (v1: vec3) (v2: vec3) = { x = v1.x /. v2.x; y = v1.y /. v2.y; z = v1.z /. v2.z }
 
 let scale s v : vec3 = {
   x = s *. v.x;


### PR DESCRIPTION
Manually defining the vector operations halves the number of allocations.

Also removed another allocation in the `aabb_hit` logic. There's probably still a bit to do there.

These tweaks give about a 40% speedup on my quadcore i7 4770k (when run with --cores 4).