### PR TITLE
Replace loop averaging with warmup for F# code

### DIFF
--- a/fsharp/README.md
+++ b/fsharp/README.md
@@ -6,5 +6,6 @@ Just `dotnet run -c release`. The following options can be specified:
 * `-n width`
 * `-f file.ppm`
 * `-s <rgbbox|irreg>`
+* `-r number of warmup runs`
 
-Requires the [].NET Core 3.1 SDK](https://dotnet.microsoft.com/download).
+Requires the [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download).


### PR DESCRIPTION
I've changed https://github.com/athas/raytracers/commit/3fd56b0c247d01e78ae337e974bf1d4815c77d26 a bit to avoid influence of first Tiered JIT runs. Idea is to warmup JIT to allow it generate optimal machine code and only then benchmark last run. So performance should be on par with `netcoreapp2.1` version.