### PR TITLE
Use JMH to benchmark for Scala implementation.

### DIFF
--- a/scala/Makefile
+++ b/scala/Makefile
@@ -13,3 +13,6 @@ irreg_1000.ppm: src/main/scala/raytracer/*
 clean:
 	sbt clean
 	rm -f *.ppm
+
+bench:
+	sbt clean bench

--- a/scala/README.md
+++ b/scala/README.md
@@ -2,3 +2,15 @@
 - run `sbt`
 - then run `run <scene> <width> <height>`
 - the output file will be written to `out.ppm`
+
+## Benchmark custom JVM version
+
+Use [Jabba](https://github.com/shyiko/jabba) to install a custom JVM version.
+For example, to run the benchmarks with GraalVM.
+
+```sh
+curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
+jabba install graalvm@20.0.0
+jabba use graalvm@20.0.0
+make bench
+```

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -15,4 +15,8 @@ scalacOptions ++= Seq(
 
 libraryDependencies += "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0"
 
+enablePlugins(JmhPlugin)
+
+addCommandAlias("bench", "jmh:run -i 3 -wi 3 -f1 -t1")
+
 // See https://www.scala-sbt.org/1.x/docs/Using-Sonatype.html for instructions on how to publish to Sonatype.

--- a/scala/project/plugins.sbt
+++ b/scala/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")

--- a/scala/src/main/scala/raytracer/Bench.scala
+++ b/scala/src/main/scala/raytracer/Bench.scala
@@ -1,0 +1,29 @@
+package raytracer
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.ExecutionContext.Implicits.global
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+class Bench {
+
+  val width = 1000
+  val height = 1000
+  @Param(Array("rgbbox", "irreg"))
+  var scene: String = _
+
+  var objscam: (Raytracer.Objs, Raytracer.Camera) = _
+  var s: Scene = _
+
+  @Setup
+  def setup(): Unit = {
+    s = Scene.fromString(scene).get
+    objscam = s.toObjsCam(width, height)
+  }
+
+  @Benchmark def construct(): Unit = s.toObjsCam(width, height)
+  @Benchmark def render(): Unit = Raytracer.render(objscam._1, width, height, objscam._2)
+}

--- a/scala/src/main/scala/raytracer/Main.scala
+++ b/scala/src/main/scala/raytracer/Main.scala
@@ -1,0 +1,29 @@
+package raytracer
+
+import scala.util.Try
+import scala.concurrent.ExecutionContext.Implicits.global
+import Raytracer._
+
+object Main extends App {
+  val (scene, width, height) = (args match {
+    case Array(s, w, h, _*) => for {
+      ss <- Scene.fromString(s)
+      ww <- Try(w.toInt).toOption
+      hh <- Try(h.toInt).toOption
+    } yield (ss, ww, hh)
+    case _ => None
+  }).getOrElse({
+    println("Error parsing command line arguments, running rgbbox 1000x1000 px")
+    (Scene.rgbbox, 1000, 1000)
+  })
+
+  val (objs, cam) = time("Constructing the scene took", 100, scene.toObjsCam(width, height))
+  val out = time("Rendering took", 5, render(objs, width, height, cam))
+
+  import java.io._
+  val pw = new PrintWriter(new File("out.ppm"))
+  pw.write(out.toPPM)
+  println("wrote output to 'out.ppm'")
+  pw.close
+
+}

--- a/scala/src/main/scala/raytracer/Raytracer.scala
+++ b/scala/src/main/scala/raytracer/Raytracer.scala
@@ -1,8 +1,6 @@
 package raytracer
 
-import scala.util.Try
-
-object Raytracer extends App {
+object Raytracer {
 
   type Pos = Vec3
   type Dir = Vec3
@@ -157,28 +155,4 @@ object Raytracer extends App {
     // First result
     timingHack.head._2
   }
-
-  val (scene, width, height) = (args match {
-    case Array(s, w, h, _*) => for {
-      ss <- Scene.fromString(s)
-      ww <- Try(w.toInt).toOption
-      hh <- Try(h.toInt).toOption
-    } yield (ss, ww, hh)
-    case _ => None
-  }).getOrElse({
-    println("Error parsing command line arguments, running rgbbox 1000x1000 px")
-    (Scene.rgbbox, 1000, 1000)
-  })
-
-  import scala.concurrent.ExecutionContext.Implicits.global
-
-  val (objs, cam) = time("Constructing the scene took", 100, scene.toObjsCam(width, height))
-  val out = time("Rendering took", 5, render(objs, width, height, cam))
-
-  import java.io._
-  val pw = new PrintWriter(new File("out.ppm"))
-  pw.write(out.toPPM)
-  println("wrote output to 'out.ppm'")
-  pw.close
-
 }

--- a/scala/src/main/scala/raytracer/Scene.scala
+++ b/scala/src/main/scala/raytracer/Scene.scala
@@ -1,6 +1,6 @@
 package raytracer
 
-import Raytracer.{Pos, Sphere, Objs, Camera}
+import Raytracer.{Pos, Sphere, Camera, Objs}
 import scala.concurrent.ExecutionContext
 
 final case class Scene(camLookFrom: Pos, camLookAt: Pos, camFov: Double, spheres: List[Sphere]) {


### PR DESCRIPTION
Thank you for creating this project!

Previously, the Scala implementation was benchmarked with
`System.nanoTime`, which is known to produce unreliable numbers on the
JVM. This commit configures the build to benchmark the Scala
implementation with JMH instead. JMH is specifically designed to run
microbenchmarks on the JVM taking into account warmup time and other
factors.

The command `sbt bench` runs three warmup iterations, three benchmark
iterations and finally print out a report like this:
```
Benchmark        (height)  (scene)  (width)  Mode  Cnt     Score      Error  Units
Bench.construct      1000   rgbbox     1000  avgt    3     0.246 ±    0.134  ms/op
Bench.construct      1000    irreg     1000  avgt    3     8.184 ±    1.626  ms/op
Bench.render         1000   rgbbox     1000  avgt    3  2862.550 ± 2098.730  ms/op
Bench.render         1000    irreg     1000  avgt    3  1327.580 ±  671.079  ms/op
```

The performance is much better when using GraalVM 20.0.0 instead of
AdoptOpenJDK 8.
```
❯ jabba install graalvm@20.0.0
❯ jabba use graalvm@20.0.0
❯ sbt bench
...
Benchmark        (scene)  Mode  Cnt    Score     Error  Units
Bench.construct   rgbbox  avgt    3    0.229 ±   0.014  ms/op
Bench.construct    irreg  avgt    3    6.187 ±   0.540  ms/op
Bench.render      rgbbox  avgt    3  824.626 ± 449.169  ms/op
Bench.render       irreg  avgt    3  277.417 ±  39.216  ms/op
```

I tried running the non-JMH benchmarks with GraalVM native-image but
got less promising results.
```
❯ jabba install graalvm@20.0.0
❯ jabba use graalvm@20.0.0
❯ gu install native-image
❯ sbt publishLocal
❯ native-image \
    -cp $(cs fetch --classpath raytracer:raytracer_2.13:0.1.0-SNAPSHOT) \
    --initialize-at-build-time \
    raytracer.Main \
    raytracer
❯ ./raytracer
Error parsing command line arguments, running rgbbox 1000x1000 px
Constructing the scene took: 1.827164ms (average over 100 repetitions)
Rendering took: 2814.0152406ms (average over 5 repetitions)
wrote output to 'out.ppm'
```

Tools used:

* `jabba`: https://github.com/shyiko/jabba
* `cs`: https://get-coursier.io/