### PR TITLE
Switch to massiv

### DIFF
--- a/haskell/Image.hs
+++ b/haskell/Image.hs
@@ -1,36 +1,9 @@
 {-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
-module Image (Image(..), Pixel, image2ppm, mkImage) where
+module Image (mkImage, writeImage) where
 
-import Control.DeepSeq
-import Control.Monad.Par
-import qualified Data.Array as A
-import Data.Word (Word8)
-import GHC.Generics (Generic)
+import Data.Massiv.Array as A
+import Data.Massiv.Array.IO
 
-type Pixel = (Word8, Word8, Word8)
-
-data Image =
-  Image { imageWidth :: Int
-        , imageHeight :: Int
-        , imagePixels :: A.Array (Int, Int) Pixel
-        -- ^ Row-major pixels.
-        }
-  deriving (Generic, NFData)
-
-image2ppm :: Image -> String
-image2ppm img =
-  unlines $
-  [ "P3"
-  , show width ++ " " ++ show height
-  , "255" ]
-  ++ map pixel2ppm (A.elems (imagePixels img))
-  where width = imageWidth img
-        height = imageHeight img
-        pixel2ppm (r, g, b) =
-          show r ++ " " ++ show g ++ " " ++ show b
-
-mkImage :: Int -> Int -> (Int -> Int -> Pixel) -> Image
-mkImage width height pixel =
-  Image width height $ A.listArray ((0,0), (height-1, width-1)) $
-  runPar $ parMap id
-  [ pixel j i | j <- [height-1,height-2..0], i <- [0..width-1] ]
+mkImage :: Int -> Int -> (Int -> Int -> Pixel SRGB Word8) -> Image S SRGB Word8
+mkImage height width pixel =
+  makeArrayR S Par (Sz2 height width) (\(i :. j) -> pixel i j)

--- a/haskell/Raytracing.hs
+++ b/haskell/Raytracing.hs
@@ -13,6 +13,8 @@ import Data.Maybe (fromMaybe)
 import BVH
 import Image
 import Vec3
+import Data.Massiv.Array (S)
+import Data.Massiv.Array.IO
 
 type Pos = Vec3
 type Dir = Vec3
@@ -176,14 +178,10 @@ traceRay objs width height cam =
               ray = getRay cam u v
           in rayColour objs ray 0
 
-colourToPixel :: Colour -> Pixel
-colourToPixel (Vec3 r g b) =
-  let ir = truncate (255.99 * r)
-      ig = truncate (255.99 * g)
-      ib = truncate (255.99 * b)
-  in (ir, ig, ib)
+colourToPixel :: Colour -> Pixel SRGB Word8
+colourToPixel (Vec3 r g b) = toPixel8 $ PixelSRGB r g b
 
-render :: Objs -> Int -> Int -> Camera -> Image
-render objs width height cam =
-  mkImage width height $ \j i ->
+render :: Objs -> Int -> Int -> Camera -> Image S SRGB Word8
+render objs height width cam =
+  mkImage height width $ \j i ->
   colourToPixel $ traceRay objs width height cam j i

--- a/haskell/ray.cabal
+++ b/haskell/ray.cabal
@@ -4,7 +4,7 @@ version: 1.0.0
 build-type: Simple
 
 common shared
-  ghc-options: -Wall -rtsopts -threaded
+  ghc-options: -Wall -rtsopts -threaded -with-rtsopts=-N
   default-language: Haskell2010
   build-depends: base, parallel, array, deepseq, monad-par
   other-modules: Raytracing, Vec3, Scene, Image, BVH

--- a/haskell/ray.cabal
+++ b/haskell/ray.cabal
@@ -6,7 +6,7 @@ build-type: Simple
 common shared
   ghc-options: -Wall -rtsopts -threaded -with-rtsopts=-N
   default-language: Haskell2010
-  build-depends: base, parallel, array, deepseq, monad-par
+  build-depends: base, parallel, massiv, massiv-io, deepseq, monad-par
   other-modules: Raytracing, Vec3, Scene, Image, BVH
 
 executable ray

--- a/haskell/ray.hs
+++ b/haskell/ray.hs
@@ -22,6 +22,6 @@ main = do
             Nothing -> error $ "Invalid scene.  Known scenes:\n" ++ unlines (map fst scenes)
             Just scene' -> do
               let (objs, cam) = fromScene width' height' scene'
-              putStr $ image2ppm $ render objs width' height' cam
+              writeImage (scene ++ ".png") $ render objs width' height' cam
     _ ->
       error $ "Usage: render <scene> <width> <height>"

--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -1,0 +1,3 @@
+resolver: nightly-2020-04-13
+packages:
+- .


### PR DESCRIPTION
This switches to `massiv` for generation of images, no other optimizations are applied

This improves the performance of Haskell implementation drastically. Benchmark results are in this commit: https://github.com/lehins/raytracers/commit/b263f9a51aafe2e2520a13b8741d211efd7e6d3e and here are criterion outputs:

* Before: https://lehins.net/content/array.html
* With massiv: https://lehins.net/content/massiv.html