### PR TITLE
[F#] Native compilation and speedup for JIT and native

### DIFF
--- a/fsharp/README.md
+++ b/fsharp/README.md
@@ -1,6 +1,9 @@
 # F# implementation
 
-Just `dotnet run -c release`. The following options can be specified:
+
+Just `dotnet run -c release`. 
+
+The following options can be specified:
 
 * `-m height`
 * `-n width`
@@ -9,3 +12,8 @@ Just `dotnet run -c release`. The following options can be specified:
 * `-r number of warmup runs`
 
 Requires the [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download).
+
+### Native Build
+Run `./linux-native.sh` this builds for the correct RID (runtime identifier) and calls the binary with the passed in options. 
+
+Note: Restore may seem to be hanging, it has to download 60+mb and that specific blob feed is quite slow for some reason. 

--- a/fsharp/linux-native.sh
+++ b/fsharp/linux-native.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+RID=linux-x64
+
+dotnet publish -r $RID -c Release trace.fsproj &&
+bin/Release/netcoreapp2.1/$RID/publish/trace $@

--- a/fsharp/nuget.config
+++ b/fsharp/nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/fsharp/trace.fsproj
+++ b/fsharp/trace.fsproj
@@ -2,12 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeIdentifiers>linux-x64;win-x64;osx-x64</RuntimeIdentifiers>
+    <IlcOptimizationPreference>Speed</IlcOptimizationPreference>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="ray.fs" />
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Manually inlining `scattered` really helped in this case, a lot of memory traffic from the tuples and optionals went away. Moving some functions from inline back to non inlined helps code quality because it allows the JIT (inline is forced by the compiler) to make a decision whether to inline or not based on method/function body size, some were already pretty chunky. Similarly moving `objsHit` back to `Option` from `ValueOption` helps because the unboxed values to pass along the recursive calls are otherwise quite big, causing stack spills and memory traffic.

Console.WriteLine is used because printfn requires reflection which complicates the native build.
netcoreapp2.1 is used because frankly it performs better in both native and jitted cases (by about 10 to 15%) . I'll investigate and ask around.

After: 
```
$ dotnet run -c release --  -f rgbbox_1000.ppm -s rgbbox -n 1000 -m 1000
Using scene 'rgbbox' (-s to switch).
Using 1 warmup runs before benchmarking (-r to change).
Scene BVH construction in 0.0003179s.
Rendering in 1.1639827s.
Writing image to rgbbox_1000.ppm.
```

Before (also one warmup run): 
```
$ dotnet run -c release --  -f rgbbox_1000.ppm -s rgbbox -n 1000 -m 1000 -r 1                                               
Using scene 'rgbbox' (-s to switch).
Using 1 warmup runs before benchmarking (-r to change).
Scene BVH construction in 0.000546s.
Rendering in 1.688101s.
Writing image to rgbbox_1000.ppm.
```

Native is even faster.
