### PR TITLE
Few tweaks on parallelisation

### DIFF
--- a/scala/src/main/scala/raytracer/BVH.scala
+++ b/scala/src/main/scala/raytracer/BVH.scala
@@ -55,7 +55,7 @@ object BVH {
             .splitAt(n / 2)
         def doLeft() = go(d+1, (n/2), xsLeft)
         def doRight() = go(d+1, n-n/2, xsRight)
-        val (left, right) = if(d > maxDepth) {
+        val (left, right) = if(d > maxDepth || n < 100) {
           (doLeft(), doRight())
         } else {
           val l = Future { doLeft() }

--- a/scala/src/main/scala/raytracer/BVH.scala
+++ b/scala/src/main/scala/raytracer/BVH.scala
@@ -41,6 +41,8 @@ final case class Split[A](aabb: AABB, left: BVH[A], right: BVH[A]) extends BVH[A
 
 object BVH {
   import scala.math.Ordering.Double.IeeeOrdering
+  val cores = Runtime.getRuntime().availableProcessors()
+  val maxDepth = (Math.log(cores)/Math.log(2)).toInt
 
   def apply[A](f: A => AABB, allObjs: List[A])(implicit ec: ExecutionContext): BVH[A] = {
 
@@ -53,7 +55,7 @@ object BVH {
             .splitAt(n / 2)
         def doLeft() = go(d+1, (n/2), xsLeft)
         def doRight() = go(d+1, n-n/2, xsRight)
-        val (left, right) = if(d > 3) {
+        val (left, right) = if(d > maxDepth) {
           (doLeft(), doRight())
         } else {
           val l = Future { doLeft() }

--- a/scala/src/main/scala/raytracer/BVH.scala
+++ b/scala/src/main/scala/raytracer/BVH.scala
@@ -27,10 +27,7 @@ final case class AABB(min: Vec3, max: Vec3) {
     }
 
   @inline def centre: Vec3 =
-    Vec3( min.x + max.x - min.x
-        , min.y + max.y - min.y
-        , min.z + max.z - min.z
-        )
+    Vec3(max.x,  max.y,  max.z)
 }
 
 sealed abstract class BVH[A] extends Product with Serializable {
@@ -56,7 +53,7 @@ object BVH {
             .splitAt(n / 2)
         def doLeft() = go(d+1, (n/2), xsLeft)
         def doRight() = go(d+1, n-n/2, xsRight)
-        val (left, right) = if(n < 100) {
+        val (left, right) = if(d > 3) {
           (doLeft(), doRight())
         } else {
           val l = Future { doLeft() }

--- a/scala/src/main/scala/raytracer/Image.scala
+++ b/scala/src/main/scala/raytracer/Image.scala
@@ -8,7 +8,7 @@ final case class Image(width: Int, height: Int, pixels: Image.PixelData) {
       s"${p._1 & 0xFF} ${p._2 & 0xFF} ${p._3 & 0xFF}"
 
     (Seq("P3", s"$width $height", "255") ++
-      pixels.par.map(pixel2ppm))
+      pixels.map(pixel2ppm))
         .mkString("\n") + "\n"
   }
 }
@@ -20,7 +20,7 @@ object Image {
   def apply(width: Int, height: Int, pixel: (Int, Int) => Pixel): Image = {
     val arr = ParSeq.tabulate(width * height)(n =>
         (height - n / height, n % width))
-    val pixelData = arr.par.map(pixel.tupled)
+    val pixelData = arr.map(pixel.tupled)
     Image(width, height, pixelData)
   }
 }

--- a/scala/src/main/scala/raytracer/Image.scala
+++ b/scala/src/main/scala/raytracer/Image.scala
@@ -8,7 +8,7 @@ final case class Image(width: Int, height: Int, pixels: Image.PixelData) {
       s"${p._1 & 0xFF} ${p._2 & 0xFF} ${p._3 & 0xFF}"
 
     (Seq("P3", s"$width $height", "255") ++
-      pixels.map(pixel2ppm))
+      pixels.par.map(pixel2ppm))
         .mkString("\n") + "\n"
   }
 }
@@ -20,7 +20,7 @@ object Image {
   def apply(width: Int, height: Int, pixel: (Int, Int) => Pixel): Image = {
     val arr = ParSeq.tabulate(width * height)(n =>
         (height - n / height, n % width))
-    val pixelData = arr.map(pixel.tupled)
+    val pixelData = arr.par.map(pixel.tupled)
     Image(width, height, pixelData)
   }
 }


### PR DESCRIPTION
Irreg improves when I limit the max depth of parallel BVH, instead of relying only on n < 100 to switch to sequential. The rest are just minor tweak map => par.map.

Master benchmark result without this change on my machine (JDK 1.8.0_242, OpenJDK 64-Bit Server VM GraalVM CE 20.0.0):
```
[info] Benchmark        (scene)  Mode  Cnt    Score     Error  Units
[info] Bench.construct   rgbbox  avgt    3    0.180 ±   0.081  ms/op
[info] Bench.construct    irreg  avgt    3    5.354 ±   2.619  ms/op
[info] Bench.render      rgbbox  avgt    3  704.752 ± 518.001  ms/op
[info] Bench.render       irreg  avgt    3  243.534 ±  75.701  ms/op
[success] Total time: 259 s (04:19), completed Apr 15, 2020 3:39:41 PM
```
Improvements I saw in this PR:
```
[info] Benchmark        (scene)  Mode  Cnt    Score     Error  Units
[info] Bench.construct   rgbbox  avgt    3    0.137 ±   0.020  ms/op
[info] Bench.construct    irreg  avgt    3    3.281 ±   0.916  ms/op
[info] Bench.render      rgbbox  avgt    3  645.399 ± 431.967  ms/op
[info] Bench.render       irreg  avgt    3  250.340 ± 295.402  ms/op
[success] Total time: 252 s (04:12), completed Apr 15, 2020 10:45:11 PM
```
The only consistent improvement I see is on Bench.construct irreg. The rest is kinda similar.
