### PR TITLE
Scala: Boost render up to 60%

### DIFF
--- a/scala/project/build.properties
+++ b/scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.3.10

--- a/scala/src/main/scala/raytracer/Raytracer.scala
+++ b/scala/src/main/scala/raytracer/Raytracer.scala
@@ -18,7 +18,8 @@ object Raytracer {
         val invD = 1.0 / dir_
         val t0 = (min_ - origin_) * invD
         val t1 = (max_ - origin_) * invD
-        val (t0_, t1_) = if (invD < 0) (t1, t0) else (t0, t1)
+        val t0_ = if (invD < 0) t1 else t0
+        val t1_ = if (invD < 0) t0 else t1
         val tMin__ = t0_ max tMin_
         val tMax__ = t1_ min tMax_
         (tMin__, tMax__)


### PR DESCRIPTION
The creation of tuples is extremely expensive in scala. By avoiding the creation at one critical place, I was able to boost `Raytracer.render` up to 50%. At least on my local machine.

Furthermore I removed the Futures in `BVH.go` which created to much parallelism. `Image.apply` (i.e. `ParSeq`) already uses all available processors/threads. By removing it, I could raise the performance up to 20% on my local machine.