### PR TITLE
Scala: Improve and speed-up implementation

### DIFF
--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -13,6 +13,10 @@ scalacOptions ++= Seq(
     "-opt-inline-from:**"
   )
 
+fork := true
+
+javaOptions := Seq("-Xms2G", "-Xmx2G", "-XX:+UseG1GC", "-XX:+UseStringDeduplication")
+
 libraryDependencies += "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0"
 
 enablePlugins(JmhPlugin)

--- a/scala/src/main/scala/raytracer/BVH.scala
+++ b/scala/src/main/scala/raytracer/BVH.scala
@@ -18,16 +18,10 @@ final case class AABB(min: Vec3, max: Vec3) {
 
   @inline def axis(d: Int): Double =
     d % 3 match {
-      case 0 => centre.x
-      case 1 => centre.y
-      case 2 => centre.z
+      case 0 => min.x + max.x - min.x
+      case 1 => min.y + max.y - min.y
+      case 2 => min.z + max.z - min.z
     }
-
-  @inline def centre: Vec3 =
-    Vec3( min.x + max.x - min.x
-        , min.y + max.y - min.y
-        , min.z + max.z - min.z
-        )
 }
 
 sealed abstract class BVH[A] extends Product with Serializable {

--- a/scala/src/main/scala/raytracer/BVH.scala
+++ b/scala/src/main/scala/raytracer/BVH.scala
@@ -1,8 +1,5 @@
 package raytracer
 import scala.collection.immutable.Nil
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration.Duration
-import scala.concurrent.ExecutionContext
 
 final case class AABB(min: Vec3, max: Vec3) {
   @inline def surroundingBox(that: AABB): AABB = {
@@ -43,30 +40,30 @@ final case class Leaf[A](aabb: AABB, a: A) extends BVH[A]
 final case class Split[A](aabb: AABB, left: BVH[A], right: BVH[A]) extends BVH[A]
 
 object BVH {
+  import java.util.concurrent.{Executors, ForkJoinPool, RecursiveTask}
   import scala.math.Ordering.Double.IeeeOrdering
 
-  def apply[A](f: A => AABB, allObjs: List[A])(implicit ec: ExecutionContext): BVH[A] = {
+  private final lazy val pool = Executors.newWorkStealingPool().asInstanceOf[ForkJoinPool]
+  sys.addShutdownHook(pool.shutdown())
 
-    def go(d: Int, n: Int, objs: List[A]): BVH[A] = objs match {
-      case Nil => throw new RuntimeException("BVH.apply: empty no nodes")
-      case x :: Nil => Leaf(f(x), x)
-      case xs => {
-        val (xsLeft, xsRight) =
-          xs.sortBy(a => f(a).axis(d))
-            .splitAt(n / 2)
-        def doLeft() = go(d+1, (n/2), xsLeft)
-        def doRight() = go(d+1, n-n/2, xsRight)
-        val (left, right) = if(n < 100) {
-          (doLeft(), doRight())
-        } else {
-          val l = Future { doLeft() }
-          val r = Future { doRight() }
-          (Await.result(l, Duration.Inf), Await.result(r, Duration.Inf))
-        }
-        val box = left.getAABB.surroundingBox(right.getAABB)
-        Split(box, left, right)
+  def apply[A](f: A => AABB, allObjs: List[A]): BVH[A] = {
+    class Go(d: Int, n: Int, objs: List[A]) extends RecursiveTask[BVH[A]] {
+      override def compute(): BVH[A] = objs match {
+        case Nil => throw new RuntimeException("BVH.apply: empty no nodes")
+        case x :: Nil => Leaf(f(x), x)
+        case xs =>
+          val (xsLeft, xsRight) = xs.sortBy(a => f(a).axis(d)).splitAt(n / 2)
+          def doLeft() = new Go(d+1, n/2, xsLeft)
+          def doRight() = new Go(d+1, n-n/2, xsRight)
+          val l = doLeft().fork()
+          val r = doRight().fork()
+          val left = l.join()
+          val right = r.join()
+          val box = left.getAABB.surroundingBox(right.getAABB)
+          Split(box, left, right)
       }
     }
-    go(0, allObjs.length, allObjs)
+
+    pool.invoke(new Go(0, allObjs.length, allObjs))
   }
 }

--- a/scala/src/main/scala/raytracer/Bench.scala
+++ b/scala/src/main/scala/raytracer/Bench.scala
@@ -3,7 +3,6 @@ package raytracer
 import org.openjdk.jmh.annotations._
 
 import java.util.concurrent.TimeUnit
-import scala.concurrent.ExecutionContext.Implicits.global
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/scala/src/main/scala/raytracer/Image.scala
+++ b/scala/src/main/scala/raytracer/Image.scala
@@ -1,27 +1,26 @@
 package raytracer
 
-import scala.collection.parallel.immutable._
+import scala.collection.parallel.immutable.ParSeq
 
 final case class Image(width: Int, height: Int, pixels: Image.PixelData) {
-  def toPPM: String = {
-    def pixel2ppm(p: Image.Pixel): String =
-      s"${p._1 & 0xFF} ${p._2 & 0xFF} ${p._3 & 0xFF}"
+  import java.io.PrintWriter
+  import scala.util.Using
 
-    (Seq("P3", s"$width $height", "255") ++
-      pixels.map(pixel2ppm))
-        .mkString("\n") + "\n"
+  def write(): Unit = Using.resource(new PrintWriter("out.ppm")) { pw =>
+    val writePPM = (p: Image.Pixel) => pw.write(s"${p.x & 0xFF} ${p.y & 0xFF} ${p.z & 0xFF}\n")
+    pw.write(s"P3\n$width $height\n255\n")
+    pixels.seq.foreach(writePPM)
   }
 }
 
 object Image {
-  type Pixel = (Byte, Byte, Byte)
   type PixelData = ParSeq[Pixel]
 
   def apply(width: Int, height: Int, pixel: (Int, Int) => Pixel): Image = {
-    val arr = ParSeq.tabulate(width * height)(n =>
-        (height - n / height, n % width))
+    val arr = ParSeq.tabulate(width * height)(n => (height - n / height, n % width))
     val pixelData = arr.map(pixel.tupled)
     Image(width, height, pixelData)
   }
-}
 
+  class Pixel(val x: Byte, val y: Byte, val z: Byte)
+}

--- a/scala/src/main/scala/raytracer/Main.scala
+++ b/scala/src/main/scala/raytracer/Main.scala
@@ -2,28 +2,24 @@ package raytracer
 
 import scala.util.Try
 import scala.concurrent.ExecutionContext.Implicits.global
-import Raytracer._
+import raytracer.Raytracer.render
 
-object Main extends App {
-  val (scene, width, height) = (args match {
-    case Array(s, w, h, _*) => for {
-      ss <- Scene.fromString(s)
-      ww <- Try(w.toInt).toOption
-      hh <- Try(h.toInt).toOption
-    } yield (ss, ww, hh)
-    case _ => None
-  }).getOrElse({
-    println("Error parsing command line arguments, running rgbbox 1000x1000 px")
-    (Scene.rgbbox, 1000, 1000)
-  })
+object Main {
+  def main(args: Array[String]): Unit = {
+    val (scene, width, height) = (args match {
+      case Array(s, w, h, _*) => for {
+        ss <- Scene.fromString(s)
+        ww <- Try(w.toInt).toOption
+        hh <- Try(h.toInt).toOption
+      } yield (ss, ww, hh)
+      case _ => None
+    }).getOrElse({
+      println("Error parsing command line arguments, running rgbbox 1000x1000 px")
+      (Scene.rgbbox, 1000, 1000)
+    })
 
-  val (objs, cam) = scene.toObjsCam(width, height)
-  val out = render(objs, width, height, cam)
-
-  import java.io._
-  val pw = new PrintWriter(new File("out.ppm"))
-  pw.write(out.toPPM)
-  println("wrote output to 'out.ppm'")
-  pw.close
-
+    val (objs, cam) = scene.toObjsCam(width, height)
+    val image = render(objs, width, height, cam)
+    image.write()
+  }
 }

--- a/scala/src/main/scala/raytracer/Main.scala
+++ b/scala/src/main/scala/raytracer/Main.scala
@@ -1,7 +1,6 @@
 package raytracer
 
 import scala.util.Try
-import scala.concurrent.ExecutionContext.Implicits.global
 import raytracer.Raytracer.render
 
 object Main {

--- a/scala/src/main/scala/raytracer/Raytracer.scala
+++ b/scala/src/main/scala/raytracer/Raytracer.scala
@@ -135,13 +135,11 @@ object Raytracer {
         i.toDouble / width.toDouble,
         j.toDouble / height.toDouble), 0)
 
-  def colorToPixel(c: Color): Image.Pixel =
-    ((255.99 * c.x).toByte, (255.99 * c.y).toByte, (255.99 * c.z).toByte)
-
-
-  def render(objs: Objs, width: Int, height: Int, camera: Camera): Image =
-    Image(width, height, (j, i) =>
-        colorToPixel(traceRay(objs, width, height, camera, j, i)))
+  def render(objs: Objs, width: Int, height: Int, camera: Camera): Image = {
+    import raytracer.Image.Pixel
+    val colorToPixel = (c: Color) => new Pixel((255.99 * c.x).toByte, (255.99 * c.y).toByte, (255.99 * c.z).toByte)
+    Image(width, height, (j, i) => colorToPixel(traceRay(objs, width, height, camera, j, i)))
+  }
 
   def time[R](text: String, reps: Int, block: => R): R = {
     val timingHack: Seq[(Double, R)] = (1 to reps).map { _ =>

--- a/scala/src/main/scala/raytracer/Raytracer.scala
+++ b/scala/src/main/scala/raytracer/Raytracer.scala
@@ -1,13 +1,11 @@
 package raytracer
 
 object Raytracer {
-
   type Pos = Vec3
   type Dir = Vec3
-
   type Color = Vec3
-  val black: Color = Vec3(0, 0, 0)
-  val white: Color = Vec3(1, 1, 1)
+  final val Black: Color = Vec3(0, 0, 0)
+  final val White: Color = Vec3(1, 1, 1)
 
   final case class Ray(origin: Pos, dir: Dir) {
 
@@ -35,50 +33,52 @@ object Raytracer {
         }
       }
     }
-
   }
+
   final case class Hit(t: Double, p: Pos, normal: Dir, color: Color)
   final case class Sphere(pos: Pos, color: Color, radius: Double) {
-    def aabb: AABB = AABB(
-      pos - Vec3(radius, radius, radius),
-      pos + Vec3(radius, radius, radius))
+    private[this] final val radiusSqrd = radius * radius
+    private[this] final val scalaFactor = 1.0 / radius
+
+    def aabb: AABB = {
+      val rVec = Vec3(radius, radius, radius)
+      AABB(pos - rVec, pos + rVec)
+    }
 
     def hit(ray: Ray, tMin: Double, tMax: Double): Option[Hit] = {
       val oc = ray.origin - pos
       val a = ray.dir dot ray.dir
       val b = oc dot ray.dir
-      val c = (oc dot oc) - radius * radius
-      val discriminant = b*b - a*c
+      val c = (oc dot oc) - radiusSqrd
+      val discriminant = b * b - a * c
+
       def tryHit(temp: Double) =
-        if(temp < tMax && temp > tMin)
-          Some(
-            Hit( temp
-               , ray.pointAtParam(temp)
-               , (ray.pointAtParam(temp) - pos).scale(1.0 / radius)
-               , color
-               ))
+        if (temp < tMax && temp > tMin) {
+          val pointAtParam = ray.pointAtParam(temp)
+          Some(Hit(temp, pointAtParam, (pointAtParam - pos).scale(scalaFactor), color))
+        }
         else None
 
-      if(discriminant <= 0) None
-      else tryHit((-b - math.sqrt(b*b - a*c)) / a) match {
-        case s: Some[Hit] => s
-        case None => tryHit((-b + math.sqrt(b*b - a*c))/a)
+      if (discriminant <= 0) None
+      else {
+        val sqrtDiscriminant = math.sqrt(discriminant)
+
+        tryHit((-b - sqrtDiscriminant) / a) match {
+          case s: Some[Hit] => s
+          case None => tryHit((-b + sqrtDiscriminant) / a)
+        }
       }
     }
-
   }
-
-    
 
   type Objs = BVH[Sphere]
 
   def objsHit(objs: Objs, ray: Ray, tMin: Double, tMax: Double): Option[Hit] = objs match {
-    case Leaf(_, sphere) =>
-      sphere.hit(ray, tMin, tMax)
+    case Leaf(_, sphere) => sphere.hit(ray, tMin, tMax)
     case Split(box, left, right) =>
       if(!ray.aabbHit(box, tMin, tMax)) None
       else objsHit(left, ray, tMin, tMax) match {
-        case Some(hit1) => Some(objsHit(right, ray, tMin, hit1.t).getOrElse(hit1))
+        case opt@Some(hit1) => objsHit(right, ray, tMin, hit1.t).orElse(opt)
         case None => objsHit(right, ray, tMin, tMax)
       }
   }
@@ -110,23 +110,19 @@ object Raytracer {
   @inline def reflect(v: Vec3, n: Vec3): Vec3 =
     v - n.scale(2 * (v dot n))
 
-  @inline def scatter(ray: Ray, hit: Hit): Option[(Ray, Vec3)] = {
-    val reflected = reflect(ray.dir.normalise, hit.normal)
-    val scattered = Ray(hit.p, reflected)
-    if((reflected dot hit.normal) > 0)
-      Some((scattered, hit.color)) else None
+  @inline def scatter(rayDir: Dir, hit: Hit): Option[Ray] = {
+    val reflected = reflect(rayDir.normalise, hit.normal)
+    if((reflected dot hit.normal) > 0) Some(Ray(hit.p, reflected)) else None
   }
 
-  def rayColor(objs: Objs, ray: Ray, depth: Int): Color = objsHit(objs, ray, 0.001, (1.0 / 0.0)) match {
-    case Some(hit) => scatter(ray, hit) match {
-      case Some((scattered, attenuation)) if depth < 50 =>
-        attenuation * rayColor(objs, scattered, depth+1)
-      case _ => black
-    }
-    case None =>
-      val unitDir = ray.dir.normalise
-      val t = 0.5 * (unitDir + Vec3.one).y
-      Vec3.one.scale(1.0-t) + Vec3(0.5, 0.7, 1).scale(t)
+  def rayColor(objs: Objs, ray: Ray, depth: Int): Color = objsHit(objs, ray, 0.001, 1.0 / 0.0) match {
+      case Some(hit) => scatter(ray.dir, hit) match {
+        case Some(scattered) if depth < 50 => hit.color * rayColor(objs, scattered, depth+1)
+        case _ => Black
+      }
+      case None =>
+        val t = 0.5 * (ray.dir.normalise.y + 1.0)
+        Vec3.one.scale(1.0-t) + Vec3(0.5, 0.7, 1).scale(t)
   }
 
   def traceRay(objs: Objs, width: Int, height: Int, camera: Camera, j: Int, i: Int): Color =

--- a/scala/src/main/scala/raytracer/Scene.scala
+++ b/scala/src/main/scala/raytracer/Scene.scala
@@ -1,10 +1,9 @@
 package raytracer
 
 import Raytracer.{Pos, Sphere, Camera, Objs}
-import scala.concurrent.ExecutionContext
 
 final case class Scene(camLookFrom: Pos, camLookAt: Pos, camFov: Double, spheres: List[Sphere]) {
-  def toObjsCam(width: Int, height: Int)(implicit ec: ExecutionContext): (Objs, Camera) =
+  def toObjsCam(width: Int, height: Int): (Objs, Camera) =
     (BVH(_.aabb, spheres), Camera(camLookFrom, camLookAt, Vec3(0,1,0), camFov, width.toDouble / height.toDouble))
 }
 


### PR DESCRIPTION
This PR contains three different changes which speed up the scala implementation (@athas If necessary, I can split it up in three different PRs):

* Rewrite saving image
* Optimize BVH by using its own thread-pool
* Minor optimizations, like avoiding duplicate calculations

Using `sbt bench` I can see a very nice boost in performance (Intel(R) Core(TM) i7-8650U CPU).
Before:
```
[info] Bench.construct   rgbbox  avgt    2     0.389          ms/op
[info] Bench.construct    irreg  avgt    2    15.754          ms/op
[info] Bench.render      rgbbox  avgt    2  1663.411          ms/op
[info] Bench.render       irreg  avgt    2   554.984          ms/op
```
After:
```
[info] Bench.construct   rgbbox  avgt    2     0.308          ms/op
[info] Bench.construct    irreg  avgt    2     8.974          ms/op
[info] Bench.render      rgbbox  avgt    2  1376.377          ms/op
[info] Bench.render       irreg  avgt    2   439.682          ms/op
```

A couple of words regarding the BVH rewrite. The default execution context is not designed for long lasting blocking operations, see [The Global Execution Context
](https://docs.scala-lang.org/overviews/core/futures.html#the-global-execution-context) for more information. In this case, every call of `Future` spawns a new thread.

As recommended, the new implementation uses a dedicated thread-pool (amount of threads = number of processors. The visualize the issue, here a couple of metrics.

Current implementation:
![threads-irreg-construct1](https://user-images.githubusercontent.com/5256214/80468838-03082880-8940-11ea-9e1c-6b0a01413a57.png)

![threads-irreg-construct2](https://user-images.githubusercontent.com/5256214/80469139-727e1800-8940-11ea-9ef7-386499b21717.png)

Spawns up multiple threads (in my case up to 20) on a 8-core machine, which leads to a low load in total (~35%).

New implementation:
![new-threads-irreg-construct1](https://user-images.githubusercontent.com/5256214/80469234-90e41380-8940-11ea-8999-55e1a9f1014c.png)
![new-threads-irreg-construct2](https://user-images.githubusercontent.com/5256214/80469253-96d9f480-8940-11ea-932e-3042386c379f.png)

The load is much higher, up to 80%.